### PR TITLE
Fix for script src's not including publicPath

### DIFF
--- a/IndexHtmlSource.js
+++ b/IndexHtmlSource.js
@@ -154,7 +154,7 @@ IndexHtmlSource.prototype._resolveScripts = function($) {
                         return new URI(file).filename().match(/\.js$/)
                     });
                     if (chunkJsFile) {
-                        $(this).attr('src', chunkJsFile);
+                        $(this).attr('src', (compilation.options.output.publicPath || '') + chunkJsFile);
                     }
                 }
             }


### PR DESCRIPTION
See https://github.com/unbroken-dome/indexhtml-webpack-plugin/issues/4
