### PR TITLE
Fix for references to files procesed by ExtractTextPlugin not including publicPath

### DIFF
--- a/IndexHtmlSource.js
+++ b/IndexHtmlSource.js
@@ -109,7 +109,7 @@ IndexHtmlSource.prototype._getHtmlFromModule = function() {
             return undefined;
 
         } else if (moduleWasExtracted(sourceModule)) {
-            return getExtractedFilename(sourceModule);
+            return (compilation.options.output.publicPath || '') + getExtractedFilename(sourceModule);
 
         } else {
             var module = {};


### PR DESCRIPTION
This is starting to feel really hacky, but it does solve the problem.
