### PR TITLE
Multiple entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ module.exports = {
     // ...
     
     plugins: [
-        new IndexHtmlPlugin('index.html', 'index.html')
+        new IndexHtmlPlugin()
     ]
     
     // ...
@@ -117,9 +117,32 @@ module.exports = {
     
     plugins: [
         cssExtractPlugin,
-        new IndexHtmlPlugin('index.html', 'index.html')
+        new IndexHtmlPlugin()
     ]
 };
+```
+
+### Options
+
+IndexHtmlPlugin takes an optional `options` object as a parameter to override
+the files it processes.
+
+#### test
+The `test` property on the `options` is a RegExp that the source file must
+match for IndexHtmlPlugin to process it.  Defaults to `/\.html$/`.
+
+#### exclude
+The `exclude` property on the `options` is a RegExp that the source file must
+*not* match for IndexHtmlPlugin to process it. If `undefined`, no files
+that match `test` will be excluded. Defaults to `undefined`.
+
+#### Example:
+
+```
+new IndexHtmlPlugin({
+  test: /\.html?$/,    // handle .htm and .html files
+  exclude: /^other\.html$/, // exclude other.html
+})
 ```
 
 ## License

--- a/index.js
+++ b/index.js
@@ -1,37 +1,43 @@
 var IndexHtmlSource = require('./IndexHtmlSource');
 
-
-function IndexHtmlPlugin(source, target) {
-
+function IndexHtmlPlugin() {
     this.apply = function apply(compiler) {
 
         compiler.plugin('this-compilation', function (compilation) {
 
+
             compilation.plugin('additional-chunk-assets', function additionalChunkAssets() {
 
-                var sourceChunk = this.namedChunks[source];
-                var sourceModule = sourceChunk.origins[0].module;
+                Object.keys(this.namedChunks).forEach(function (source) {
+                    if (/\.html$/.test(source)) {
+                        var sourceChunk = this.namedChunks[source];
+                        var sourceModule = sourceChunk.origins[0].module;
 
-                var filePath = this.getPath(target, {chunk: sourceChunk});
-                this.additionalChunkAssets.push(filePath);
-                this.assets[filePath] = new IndexHtmlSource(sourceModule, sourceChunk, this);
-                sourceChunk.files.push(filePath);
+                        var filePath = this.getPath(source, { chunk: sourceChunk });
+                        this.additionalChunkAssets.push(filePath);
+                        this.assets[filePath] = new IndexHtmlSource(sourceModule, sourceChunk, this);
+                        sourceChunk.files.push(filePath);
+                    }
+                }, this);
             });
         });
 
         compiler.plugin('emit', function emit(compilation, callback) {
 
             Object.keys(compilation.assets).forEach(function (file) {
+                Object.keys(compilation.namedChunks).forEach(function (source) {
+                    if (/\.html$/.test(source)) {
+                        var targetFile = file;
+                        var queryStringIdx = targetFile.indexOf('?');
+                        if (queryStringIdx >= 0) {
+                            targetFile = targetFile.substr(0, queryStringIdx);
+                        }
 
-                var targetFile = file;
-                var queryStringIdx = targetFile.indexOf('?');
-                if (queryStringIdx >= 0) {
-                    targetFile = targetFile.substr(0, queryStringIdx);
-                }
-
-                if (targetFile === source + '.js' || targetFile === source + '.js.map') {
-                    delete compilation.assets[file];
-                }
+                        if (targetFile === source + '.js' || targetFile === source + '.js.map') {
+                            delete compilation.assets[file];
+                        }
+                    }
+                });
             });
 
             callback();

--- a/index.js
+++ b/index.js
@@ -1,15 +1,32 @@
 var IndexHtmlSource = require('./IndexHtmlSource');
 
-function IndexHtmlPlugin() {
+function IndexHtmlPlugin(options) {
+    options = options || {};
+
+    if (!options.test) {
+      options.test = /\.html$/;
+    }
+
+    var matches = function(source) {
+        if (!options.test.test(source)) {
+            return false;
+        }
+
+        if (options.exclude && options.exclude.test(source)) {
+            return false;
+        }
+
+        return true;
+    };
+
     this.apply = function apply(compiler) {
 
         compiler.plugin('this-compilation', function (compilation) {
 
-
             compilation.plugin('additional-chunk-assets', function additionalChunkAssets() {
 
                 Object.keys(this.namedChunks).forEach(function (source) {
-                    if (/\.html$/.test(source)) {
+                    if (matches(source)) {
                         var sourceChunk = this.namedChunks[source];
                         var sourceModule = sourceChunk.origins[0].module;
 
@@ -26,7 +43,7 @@ function IndexHtmlPlugin() {
 
             Object.keys(compilation.assets).forEach(function (file) {
                 Object.keys(compilation.namedChunks).forEach(function (source) {
-                    if (/\.html$/.test(source)) {
+                    if (matches(source)) {
                         var targetFile = file;
                         var queryStringIdx = targetFile.indexOf('?');
                         if (queryStringIdx >= 0) {


### PR DESCRIPTION
This adds support for multiple .html entry points to IndexHtmlPlugin. By default it processes any entries with the .html suffix but the consumer can provide an options object to the IndexHtmlPlugin to customize this.
